### PR TITLE
revert: powertools is not available for Rocky9

### DIFF
--- a/Dockerfile.rockylinux9
+++ b/Dockerfile.rockylinux9
@@ -17,7 +17,6 @@ RUN set -ex; \
         dnf-plugins-core \
         epel-release \
     ; \
-    yum config-manager --set-enabled powertools; \
     /usr/local/bin/retry yum -q -y --nodocs install \
         https://mirror.in2p3.fr/pub/epel/9/Everything/x86_64/Packages/b/bats-1.8.0-1.el9.noarch.rpm \
         findutils \


### PR DESCRIPTION

Fixing previous commit