### PR TITLE
Use image maintained by rockylinux team for RH9

### DIFF
--- a/Dockerfile.rockylinux9
+++ b/Dockerfile.rockylinux9
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM rockylinux/rockylinux:9
 
 ADD common/retry /usr/local/bin
 ADD https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh /usr/local/bin/


### PR DESCRIPTION
Instead of unmaintained image by the Docker team. 